### PR TITLE
move msi to s3

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,7 +44,7 @@ if node['nxlog']['checksums'][package_name]
 else
   remote_file 'nxlog' do
     path "#{Chef::Config[:file_cache_path]}/#{package_name}"
-    source "http://nxlog.org/system/files/products/files/1/#{package_name}"
+    source "https://s3.amazonaws.com/ps-deploy-artifacts/nx-log-installer/nxlog-ce-2.9.1504.msi"
     mode 0644
   end
 end

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-package_name = "nxlog-ce-#{node['nxlog']['version']}.msi"
+package_name = "NO CHECKSUM HERE" #"nxlog-ce-#{node['nxlog']['version']}.msi"
 
 node.default['nxlog']['installer_package'] = package_name


### PR DESCRIPTION
nxlog only allows for free access to the latest msi.  This makes
automation hard because we have to update our code for every
point release.

Screw that.

copy the current MSI to S3, make it public and go with god.
